### PR TITLE
replaced extra write-hosts and subexpressions

### DIFF
--- a/wsl-install.ps1
+++ b/wsl-install.ps1
@@ -1,24 +1,22 @@
 param(
-  [string]$DistroPath = $("C:\Program Files\WindowsApps"),
-  [string]$DistroCachePath = $(".\"),
-  [string]$DistroName = $("ubuntu"),
-  [string]$DistroVersion = $("1804"),
-  [string]$DistroAppx = $("CanonicalGroupLimited.Ubuntu18.04onWindows"),
+  [string]$DistroPath = "C:\Program Files\WindowsApps",
+  [string]$DistroCachePath = ".\",
+  [string]$DistroName = "ubuntu",
+  [string]$DistroVersion = "1804",
+  [string]$DistroAppx = "CanonicalGroupLimited.Ubuntu18.04onWindows",
   [switch]$Force = $False
 )
 
-$OutputPrefix=">> "
-$OutputForced=" (-Force)"
+$OutputPrefix = "$([char]27)[92m>>$([char]27)[0m"
+$OutputForced = " (-Force)"
 
 # Enable Windows Subsystem for Linux (WSL) in Windows features (reboot prompt if not already enabled).
-Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green
-Write-Host "Enabling Windows Susbsystem for Linux..."
+Write-Host "$OutputPrefix Enabling Windows Susbsystem for Linux..."
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Windows-Subsystem-Linux
 
 if(((Test-Path "$DistroCachePath\$DistroName-$DistroVersion.appx" -PathType Leaf) -eq $False) -or ($Force -eq $True)){
   # Download WSL distrobution.
-  Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green
-  Write-Host "Downloading $DistroName ($DistroVersion)..." -NoNewline
+  Write-Host "$OutputPrefix Downloading $DistroName ($DistroVersion)..." -NoNewLine
   if($Force -eq $True){
     Write-Host "$OutputForced" -ForegroundColor Yellow
   } else {
@@ -29,8 +27,7 @@ if(((Test-Path "$DistroCachePath\$DistroName-$DistroVersion.appx" -PathType Leaf
 
 if((Test-Path "$DistroCachePath\$DistroName-$DistroVersion.appx" -PathType Leaf) -eq $True){
   # Install WSL distrobution.
-  Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green
-  Write-Host "Installing $DistroName ($DistroVersion)..."
+  Write-Host "$OutputPrefix Installing $DistroName ($DistroVersion)..."
   Add-AppxPackage -Path "$DistroCachePath\$DistroName-$DistroVersion.appx"
 }
 
@@ -39,12 +36,10 @@ $DistroPackage = $(Get-AppxPackage -Name "$DistroAppx" | Select-String -Pattern 
 
 if($DistroPackage){
   # Configure WSL distrobution.
-  Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green
-  Write-Host "Configuring $DistroName ($DistroVersion)..."
+  Write-Host "$OutputPrefix Configuring $DistroName ($DistroVersion)..."
   Invoke-Expression "& '$DistroPath\$DistroPackage\$DistroName$DistroVersion.exe' install --root"
 
-  Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green
-  Write-Host "Lauching $DistroName ($DistroVersion)..."
+  Write-Host "$OutputPrefix Lauching $DistroName ($DistroVersion)..."
   Start-Process "$DistroPath\$DistroPackage\$DistroName$DistroVersion.exe"
   
   exit


### PR DESCRIPTION
Proposed changes:

- The subexpression operator `$( )` isn't needed for simple strings

- Also replaced all `Write-Host "$OutputPrefix" -NoNewline -ForegroundColor Green` lines by integrating the text coloring into the $OutputPrefix variable - makes everything shorter and nicer. This technique will only work on Windows 10 v1703 and newer, but WSL didn't exist before then anyway so this isn't a problem.

I hope this PR is welcome :)